### PR TITLE
Rename auth provider component

### DIFF
--- a/client/src/context/authContext.js
+++ b/client/src/context/authContext.js
@@ -3,7 +3,7 @@ import { createContext, useEffect, useState } from "react";
 
 export const AuthContext = createContext();
 
-export const AuthContexProvider = ({ children }) => {
+export const AuthContextProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(
     JSON.parse(localStorage.getItem("user")) || null
   );
@@ -22,7 +22,7 @@ export const AuthContexProvider = ({ children }) => {
     localStorage.setItem("user", JSON.stringify(currentUser));
   }, [currentUser]);
 
-  return ( 
+  return (
     <AuthContext.Provider value={{ currentUser, login, logout }}>
       {children}
     </AuthContext.Provider>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { AuthContexProvider } from "./context/authContext";
+import { AuthContextProvider } from "./context/authContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <AuthContexProvider>
+    <AuthContextProvider>
       <App />
-    </AuthContexProvider>
+    </AuthContextProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- rename `AuthContexProvider` to `AuthContextProvider`
- update imports to use the new provider name

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acaca1561483208db5606285ee9c26